### PR TITLE
Fix: `CustomAppBar` 뒤로가기 기능 미작동 오류 해결

### DIFF
--- a/lib/screens/entry_screen.dart
+++ b/lib/screens/entry_screen.dart
@@ -6,75 +6,71 @@ class EntryScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        backgroundColor: const Color(0xFFFFF6F4),
-        body: Container(
+    return Scaffold(
+      backgroundColor: const Color(0xFFFFF6F4),
+      body: Container(
+          //background blur img
+          width: double.infinity,
+          height: double.infinity,
+          decoration: const BoxDecoration(
+              image: DecorationImage(
+            image: AssetImage('assets/images/blur1.png'),
+            fit: BoxFit.cover,
+          )),
+          child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+            const Spacer(
+              flex: 2,
+            ),
 
-            //background blur img
-            width: double.infinity,
-            height: double.infinity,
-            decoration: const BoxDecoration(
-                image: DecorationImage(
-              image: AssetImage('assets/images/blur1.png'),
-              fit: BoxFit.cover,
-            )),
-            child:
-                Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-              const Spacer(
-                flex: 2,
+            // LINRING text
+            Text(
+              'LINRING',
+              style: TextStyle(
+                color: Colors.white.withOpacity(0.75),
+                fontSize: 55,
+                fontWeight: FontWeight.w900,
+                height: 0,
+                letterSpacing: 1.80,
               ),
+            ),
 
-              // LINRING text
-              Text(
-                'LINRING',
-                style: TextStyle(
-                  color: Colors.white.withOpacity(0.75),
-                  fontSize: 55,
-                  fontWeight: FontWeight.w900,
-                  height: 0,
-                  letterSpacing: 1.80,
-                ),
+            //너와 나를 잇는 울림 text
+            const Text(
+              '너와 나를 잇는 울림',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 20,
+                fontWeight: FontWeight.w400,
+                height: 0,
               ),
+            ),
 
-              //너와 나를 잇는 울림 text
-              const Text(
-                '너와 나를 잇는 울림',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 20,
-                  fontWeight: FontWeight.w400,
-                  height: 0,
-                ),
-              ),
+            //로그인 버튼
+            const Spacer(
+              flex: 1,
+            ),
 
-              //로그인 버튼
-              const Spacer(
-                flex: 1,
-              ),
+            //로그인 버튼
+            CustomOutlinedButton(
+                label: '로그인',
+                onPressed: () => {
+                      Navigator.pushNamed(context, '/login'),
+                    },
+                backgroundColor: Colors.white),
 
-              //로그인 버튼
-              CustomOutlinedButton(
-                  label: '로그인',
-                  onPressed: () => {
-                        Navigator.pushNamed(context, '/login'),
-                      },
-                  backgroundColor: Colors.white),
+            const SizedBox(
+              height: 10,
+            ),
 
-              const SizedBox(
-                height: 10,
-              ),
-
-              //회원가입 버튼
-              CustomOutlinedButton(
-                  label: '회원가입',
-                  onPressed: () => {Navigator.pushNamed(context, '/signup')},
-                  backgroundColor: const Color(0xFFFEC2B5)),
-              const Spacer(
-                flex: 1,
-              )
-            ])),
-      ),
+            //회원가입 버튼
+            CustomOutlinedButton(
+                label: '회원가입',
+                onPressed: () => {Navigator.pushNamed(context, '/signup')},
+                backgroundColor: const Color(0xFFFEC2B5)),
+            const Spacer(
+              flex: 1,
+            )
+          ])),
     );
   }
 }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:linring_front_flutter/widgets/custom_appbar.dart';
 import 'package:linring_front_flutter/widgets/custom_outlined_button.dart';
 import 'package:linring_front_flutter/widgets/custom_textfield.dart';
 
@@ -14,30 +15,9 @@ class _LoginScreenState extends State<LoginScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-        home: Scaffold(
+    return Scaffold(
       backgroundColor: const Color(0xFFFFF6F4),
-      //appBar: CustomAppBar(title: '로그인'),
-      appBar: AppBar(
-        title: const Text(
-          '로그인',
-          style: TextStyle(
-              color: Colors.black,
-              fontSize: 26,
-              fontWeight: FontWeight.w500,
-              height: 0),
-        ),
-        centerTitle: true,
-        leading: IconButton(
-            onPressed: () => {
-                  if (Navigator.of(context).canPop())
-                    {Navigator.of(context).pop()} //뒤로가기
-                },
-            color: const Color.fromARGB(255, 0, 0, 0),
-            icon: const Icon(Icons.arrow_back)),
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-      ),
+      appBar: const CustomAppBar(title: '로그인'),
       body: Container(
           //background blur img
           width: double.infinity,
@@ -137,6 +117,6 @@ class _LoginScreenState extends State<LoginScreen> {
               flex: 1,
             )
           ])),
-    ));
+    );
   }
 }

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -3,6 +3,7 @@ import 'package:linring_front_flutter/screens/chat_screen.dart';
 import 'package:linring_front_flutter/screens/setting_screen.dart';
 import 'package:linring_front_flutter/screens/tag_show_screen.dart';
 import 'package:linring_front_flutter/widgets/bottom_navigation_bar.dart';
+import 'package:linring_front_flutter/widgets/custom_appbar.dart';
 
 class MainScreen extends StatefulWidget {
   const MainScreen({Key? key}) : super(key: key);
@@ -23,31 +24,7 @@ class _MainScreenState extends State<MainScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        elevation: 0.0,
-        title: const Text(
-          "LINRING",
-          style: TextStyle(
-            color: Colors.black,
-          ),
-        ),
-        backgroundColor: const Color(0xfffff6f4),
-        automaticallyImplyLeading: true,
-        leading: IconButton(
-          color: Colors.black,
-          onPressed: () => {
-            Navigator.of(context).canPop() ? Navigator.of(context).pop() : true
-          },
-          icon: const Icon(Icons.arrow_back),
-        ),
-        actions: [
-          IconButton(
-            color: Colors.black,
-            onPressed: () {},
-            icon: const Icon(Icons.notifications),
-          )
-        ],
-      ),
+      appBar: const CustomAppBar(title: "LINRING"),
       bottomNavigationBar: CustomBottomNavigationBar(
         selectedIndex: _selectedIndex,
         onIndexChanged: (index) {

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -35,235 +35,231 @@ class _SignUpScreenState extends State<SignUpScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-        home: Scaffold(
-            backgroundColor: const Color(0xFFFFF6F4),
-            appBar: const CustomAppBar(
-              title: '회원가입',
+    return Scaffold(
+      backgroundColor: const Color(0xFFFFF6F4),
+      appBar: const CustomAppBar(
+        title: '회원가입',
+      ),
+      body: SingleChildScrollView(
+        child:
+            Column(mainAxisAlignment: MainAxisAlignment.spaceAround, children: [
+          const SizedBox(
+            height: 40,
+          ),
+          //아이디
+          const Padding(
+              padding: EdgeInsets.only(left: 30.0),
+              child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '아이디',
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 20,
+                      fontWeight: FontWeight.w400,
+                      height: 0,
+                    ),
+                  ))),
+          const CustomTextField(
+            obscureText: false,
+            suffixText: Text('@kookmin.ac.kr'),
+          ),
+          const SizedBox(height: 30),
+          //비밀번호
+          const Padding(
+              padding: EdgeInsets.only(left: 30.0),
+              child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '비밀번호',
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 20,
+                      fontWeight: FontWeight.w400,
+                      height: 0,
+                    ),
+                  ))),
+          const CustomTextField(
+            hintText: '',
+            obscureText: false,
+          ),
+
+          const SizedBox(height: 30),
+
+          //비밀번호 확인
+          const Padding(
+              padding: EdgeInsets.only(left: 30.0),
+              child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '비밀번호 확인',
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 20,
+                      fontWeight: FontWeight.w400,
+                      height: 0,
+                    ),
+                  ))),
+          const CustomTextField(
+            hintText: '',
+            obscureText: false,
+          ),
+
+          const SizedBox(height: 30),
+
+          //닉네임
+          const Padding(
+              padding: EdgeInsets.only(left: 30.0),
+              child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '닉네임',
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 20,
+                      fontWeight: FontWeight.w400,
+                      height: 0,
+                    ),
+                  ))),
+          const CustomTextField(
+            hintText: '6글자 이내의 닉네임',
+            obscureText: false,
+          ),
+
+          const SizedBox(height: 30),
+
+          //학과(제1전공)
+          const Padding(
+              padding: EdgeInsets.only(left: 30.0),
+              child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '학과(제1전공)',
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 20,
+                      fontWeight: FontWeight.w400,
+                      height: 0,
+                    ),
+                  ))),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(30, 5, 30, 5),
+            child: OutlinedButton(
+                onPressed: () {
+                  Navigator.pushNamed(context, '/selectmajor');
+                },
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: Colors.black,
+                  backgroundColor: Colors.white,
+                  side: const BorderSide(width: 1, color: Color(0xFFC8AAAA)),
+                  elevation: 5,
+                  shadowColor: const Color(0x196C5916),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  fixedSize: const Size(350, 60),
+                ),
+                child: const Align(
+                    alignment: Alignment.centerRight,
+                    child: Icon(
+                      Icons.search,
+                      size: 24.0,
+                      color: Colors.black,
+                    ))),
+          ),
+
+          const SizedBox(height: 30),
+
+          //학번 및 학년
+          const Padding(
+              padding: EdgeInsets.only(left: 30.0),
+              child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '학번 및 학년',
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 20,
+                      fontWeight: FontWeight.w400,
+                      height: 0,
+                    ),
+                  ))),
+          const CustomTextField(
+            hintText: '',
+            obscureText: false,
+          ),
+
+          const SizedBox(height: 30),
+
+          //성별 및 나이
+          const Padding(
+              padding: EdgeInsets.fromLTRB(30, 0, 0, 5),
+              child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '성별 및 나이',
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 20,
+                      fontWeight: FontWeight.w400,
+                      height: 0,
+                    ),
+                  ))),
+          Container(
+            padding: EdgeInsets.zero,
+            decoration: BoxDecoration(
+              color: Colors.white,
+              border: Border.all(color: const Color(0xFFC8AAAA), width: 1.0),
+              borderRadius: const BorderRadius.all(Radius.circular(10.0)),
             ),
-            body: SingleChildScrollView(
-              child: Column(
-                  mainAxisAlignment: MainAxisAlignment.spaceAround,
-                  children: [
-                    const SizedBox(
-                      height: 40,
+            child: ToggleButtons(
+              isSelected: isSelected,
+              onPressed: toggleSelect,
+              fillColor: const Color(0xFFFEC2B5),
+              selectedColor: Colors.black,
+              children: const [
+                Padding(
+                    padding: EdgeInsets.fromLTRB(30, 5, 30, 5),
+                    child: Text('여')),
+                Padding(
+                    padding: EdgeInsets.fromLTRB(30, 5, 30, 5),
+                    child: Text('남')),
+              ],
+            ),
+          ),
+
+          const SizedBox(height: 30),
+
+          //특이사항
+          const Padding(
+              padding: EdgeInsets.fromLTRB(30, 0, 0, 5),
+              child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '특이사항',
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 20,
+                      fontWeight: FontWeight.w400,
+                      height: 0,
                     ),
-                    //아이디
-                    const Padding(
-                        padding: EdgeInsets.only(left: 30.0),
-                        child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text(
-                              '아이디',
-                              style: TextStyle(
-                                color: Colors.black,
-                                fontSize: 20,
-                                fontWeight: FontWeight.w400,
-                                height: 0,
-                              ),
-                            ))),
-                    const CustomTextField(
-                      obscureText: false,
-                      suffixText: Text('@kookmin.ac.kr'),
-                    ),
-                    const SizedBox(height: 30),
-                    //비밀번호
-                    const Padding(
-                        padding: EdgeInsets.only(left: 30.0),
-                        child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text(
-                              '비밀번호',
-                              style: TextStyle(
-                                color: Colors.black,
-                                fontSize: 20,
-                                fontWeight: FontWeight.w400,
-                                height: 0,
-                              ),
-                            ))),
-                    const CustomTextField(
-                      hintText: '',
-                      obscureText: false,
-                    ),
+                  ))),
+          Wrap(
+              alignment: WrapAlignment.start,
+              children: List.generate(remark.length, (index) {
+                return buildRemark(index);
+              })),
 
-                    const SizedBox(height: 30),
-
-                    //비밀번호 확인
-                    const Padding(
-                        padding: EdgeInsets.only(left: 30.0),
-                        child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text(
-                              '비밀번호 확인',
-                              style: TextStyle(
-                                color: Colors.black,
-                                fontSize: 20,
-                                fontWeight: FontWeight.w400,
-                                height: 0,
-                              ),
-                            ))),
-                    const CustomTextField(
-                      hintText: '',
-                      obscureText: false,
-                    ),
-
-                    const SizedBox(height: 30),
-
-                    //닉네임
-                    const Padding(
-                        padding: EdgeInsets.only(left: 30.0),
-                        child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text(
-                              '닉네임',
-                              style: TextStyle(
-                                color: Colors.black,
-                                fontSize: 20,
-                                fontWeight: FontWeight.w400,
-                                height: 0,
-                              ),
-                            ))),
-                    const CustomTextField(
-                      hintText: '6글자 이내의 닉네임',
-                      obscureText: false,
-                    ),
-
-                    const SizedBox(height: 30),
-
-                    //학과(제1전공)
-                    const Padding(
-                        padding: EdgeInsets.only(left: 30.0),
-                        child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text(
-                              '학과(제1전공)',
-                              style: TextStyle(
-                                color: Colors.black,
-                                fontSize: 20,
-                                fontWeight: FontWeight.w400,
-                                height: 0,
-                              ),
-                            ))),
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(30, 5, 30, 5),
-                      child: OutlinedButton(
-                          onPressed: () {
-                            Navigator.pushNamed(context, '/selectmajor');
-                          },
-                          style: OutlinedButton.styleFrom(
-                            foregroundColor: Colors.black,
-                            backgroundColor: Colors.white,
-                            side: const BorderSide(
-                                width: 1, color: Color(0xFFC8AAAA)),
-                            elevation: 5,
-                            shadowColor: const Color(0x196C5916),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(10),
-                            ),
-                            fixedSize: const Size(350, 60),
-                          ),
-                          child: const Align(
-                              alignment: Alignment.centerRight,
-                              child: Icon(
-                                Icons.search,
-                                size: 24.0,
-                                color: Colors.black,
-                              ))),
-                    ),
-
-                    const SizedBox(height: 30),
-
-                    //학번 및 학년
-                    const Padding(
-                        padding: EdgeInsets.only(left: 30.0),
-                        child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text(
-                              '학번 및 학년',
-                              style: TextStyle(
-                                color: Colors.black,
-                                fontSize: 20,
-                                fontWeight: FontWeight.w400,
-                                height: 0,
-                              ),
-                            ))),
-                    const CustomTextField(
-                      hintText: '',
-                      obscureText: false,
-                    ),
-
-                    const SizedBox(height: 30),
-
-                    //성별 및 나이
-                    const Padding(
-                        padding: EdgeInsets.fromLTRB(30, 0, 0, 5),
-                        child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text(
-                              '성별 및 나이',
-                              style: TextStyle(
-                                color: Colors.black,
-                                fontSize: 20,
-                                fontWeight: FontWeight.w400,
-                                height: 0,
-                              ),
-                            ))),
-                    Container(
-                      padding: EdgeInsets.zero,
-                      decoration: BoxDecoration(
-                        color: Colors.white,
-                        border: Border.all(
-                            color: const Color(0xFFC8AAAA), width: 1.0),
-                        borderRadius:
-                            const BorderRadius.all(Radius.circular(10.0)),
-                      ),
-                      child: ToggleButtons(
-                        isSelected: isSelected,
-                        onPressed: toggleSelect,
-                        fillColor: const Color(0xFFFEC2B5),
-                        selectedColor: Colors.black,
-                        children: const [
-                          Padding(
-                              padding: EdgeInsets.fromLTRB(30, 5, 30, 5),
-                              child: Text('여')),
-                          Padding(
-                              padding: EdgeInsets.fromLTRB(30, 5, 30, 5),
-                              child: Text('남')),
-                        ],
-                      ),
-                    ),
-
-                    const SizedBox(height: 30),
-
-                    //특이사항
-                    const Padding(
-                        padding: EdgeInsets.fromLTRB(30, 0, 0, 5),
-                        child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Text(
-                              '특이사항',
-                              style: TextStyle(
-                                color: Colors.black,
-                                fontSize: 20,
-                                fontWeight: FontWeight.w400,
-                                height: 0,
-                              ),
-                            ))),
-                    Wrap(
-                        alignment: WrapAlignment.start,
-                        children: List.generate(remark.length, (index) {
-                          return buildRemark(index);
-                        })),
-
-                    //동의
-                    const SizedBox(height: 40),
-                    //가입하기 버튼
-                    CustomOutlinedButton(
-                        label: '가입하기',
-                        onPressed: () {},
-                        backgroundColor: const Color(0xFFFEC2B5)),
-                  ]),
-            )));
+          //동의
+          const SizedBox(height: 40),
+          //가입하기 버튼
+          CustomOutlinedButton(
+              label: '가입하기',
+              onPressed: () {},
+              backgroundColor: const Color(0xFFFEC2B5)),
+        ]),
+      ),
+    );
   }
 
   void toggleSelect(value) {

--- a/lib/screens/tag_add_screen.dart
+++ b/lib/screens/tag_add_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:linring_front_flutter/widgets/custom_appbar.dart';
 
 class Tag {
   String id;
@@ -15,26 +16,9 @@ class TagAddScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        elevation: 0.0,
-        title: const Text(
-          "태그 추가하기",
-          style: TextStyle(
-            color: Colors.black,
-          ),
-        ),
-        backgroundColor: const Color(0xfffff6f4),
-        automaticallyImplyLeading: true,
-        leading: IconButton(
-          color: Colors.black,
-          onPressed: () => {
-            Navigator.of(context).canPop() ? Navigator.of(context).pop() : true
-          },
-          icon: const Icon(Icons.arrow_back),
-        ),
-      ),
-      body: const Column(children: [
+    return const Scaffold(
+      appBar: CustomAppBar(title: "태그 추가하기"),
+      body: Column(children: [
         ChoiceLocation(),
       ]),
     );

--- a/lib/widgets/custom_appbar.dart
+++ b/lib/widgets/custom_appbar.dart
@@ -2,8 +2,7 @@ import 'package:flutter/material.dart';
 
 class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;
-  const CustomAppBar({Key? key, required this.title, onPressed})
-      : super(key: key);
+  const CustomAppBar({Key? key, required this.title}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
This PR resolves #8
This PR resolves #9 

아래와 같은 변경 및 개선점이 있습니다.

1. `CustomAppBar`의 파라미터 `onPressed` 제거
    - 현재 `CustomAppBar` 한 가지 기능(뒤로 가기)만을 공유하기 때문에 삭제하였습니다.
    - 추후 다른 동작을 전달 받아 수행해야 한다면 추가하는 방향으로 가면 좋을 거 같습니다.
2. `MaterialApp` unwrapping
    - 기존 `CustomAppBar`의 뒤로가기 기능이 수행되지 않는 이유가 하나의 서비스에서 `MaterialApp`를 사용하였기 때문이었던 것으로 보입니다. 
    - Flutter에서 `MaterialApp`은 최상위 루트 위젯으로 앱 전체의 테마(Theme)나 네비게이션(Navigation) 구조를 정할 때 **한 번** 사용합니다. -> 분리된 모듈, 서브 앱 사용이나 다른 테마 사용 등의 경우에만 `MaterialApp`을 사용하는 것이 권장 사항입니다! (페이지는 `Scaffold`를 이용)
    
3. 기존 하드 코딩된 `appBar` 수정
    - 구현된 `CustomAppBar`를 이용하는 방식으로 수정하였습니다.(Issue #9 와 관련)