### PR TITLE
Feat: `TagAddScreen` UI 구현 및 `CustomTextField` 수정

### DIFF
--- a/lib/screens/tag_add_screen.dart
+++ b/lib/screens/tag_add_screen.dart
@@ -380,6 +380,7 @@ class _ChoiceLocationState extends State<ChoiceLocation> {
             height: 8,
           ),
           CustomTextField(
+            textLimit: 30,
             onChanged: (value) => {introduction = value},
             obscureText: false,
             hintText: "ex. 같이 카페에서 각자 공부할 사람 구해요!",

--- a/lib/screens/tag_add_screen.dart
+++ b/lib/screens/tag_add_screen.dart
@@ -113,135 +113,278 @@ class _ChoiceLocationState extends State<ChoiceLocation> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Wrap(
-          spacing: 8,
-          children: _tagPlace.map((tag) {
-            return ChoiceChip(
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  side: const BorderSide(width: 2, color: Color(0xFFFEC2B5))),
-              labelPadding: const EdgeInsets.fromLTRB(5, 0, 5, 0),
-              label: Text(tag.title),
-              selected: place == tag.title,
-              selectedColor: const Color(0xfffec2b5),
-              onSelected: (selected) {
-                setState(() {
-                  if (selected) {
-                    place = tag.title;
-                  } else {
-                    place = null;
-                  }
-                });
-              },
-              backgroundColor: Colors.white,
-              elevation: 0,
-            );
-          }).toList(),
-        ),
-        const SizedBox(
-          height: 10,
-        ),
-        Wrap(
-          spacing: 8,
-          children: _tagDepartment.map(
-            (tag) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(
+            height: 16,
+          ),
+          Row(
+            children: [
+              Container(
+                width: 156,
+                decoration: const BoxDecoration(
+                  border: BorderDirectional(
+                    bottom: BorderSide(
+                      color: Color(0xffc8aaaa),
+                      width: 1,
+                    ),
+                  ),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(5.0),
+                  child: Text(
+                    place ?? "",
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      fontSize: 18,
+                    ),
+                  ),
+                ),
+              ),
+              const Padding(
+                padding: EdgeInsets.all(5.0),
+                child: Text(
+                  "에서",
+                  style: TextStyle(
+                    fontSize: 18,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(
+            height: 10,
+          ),
+          Wrap(
+            spacing: 8,
+            children: _tagPlace.map((tag) {
               return ChoiceChip(
                 shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(8),
                     side: const BorderSide(width: 2, color: Color(0xFFFEC2B5))),
                 labelPadding: const EdgeInsets.fromLTRB(5, 0, 5, 0),
-                label: Text(
-                  tag.title,
-                  style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: const Color(0xff1b1b1b),
-                        fontSize: 16,
-                        fontWeight: FontWeight.w400,
-                      ),
-                ),
-                selected: department == tag.title,
+                label: Text(tag.title),
+                selected: place == tag.title,
                 selectedColor: const Color(0xfffec2b5),
                 onSelected: (selected) {
-                  setState(
-                    () {
-                      if (selected) {
-                        department = tag.title;
-                      } else {
-                        department = null;
-                      }
-                    },
-                  );
+                  setState(() {
+                    if (selected) {
+                      place = tag.title;
+                    } else {
+                      place = null;
+                    }
+                  });
                 },
                 backgroundColor: Colors.white,
                 elevation: 0,
               );
-            },
-          ).toList(),
-        ),
-        const SizedBox(
-          height: 10,
-        ),
-        Wrap(
-          spacing: 8,
-          children: _tagPerson.map((tag) {
-            return ChoiceChip(
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  side: const BorderSide(width: 2, color: Color(0xFFFEC2B5))),
-              labelPadding: const EdgeInsets.fromLTRB(5, 0, 5, 0),
-              label: Text(tag.title),
-              selected: person == tag.title,
-              selectedColor: const Color(0xFFFEC2B5),
-              onSelected: (selected) {
-                setState(() {
-                  if (selected) {
-                    person = tag.title;
-                  } else {
-                    person = null;
-                  }
-                });
+            }).toList(),
+          ),
+          const SizedBox(
+            height: 10,
+          ),
+          Row(
+            children: [
+              Container(
+                width: 156,
+                decoration: const BoxDecoration(
+                  border: BorderDirectional(
+                    bottom: BorderSide(
+                      color: Color(0xffc8aaaa),
+                      width: 1,
+                    ),
+                  ),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(5.0),
+                  child: Text(
+                    "${department ?? ""} ${person ?? ""}",
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      fontSize: 18,
+                    ),
+                  ),
+                ),
+              ),
+              const Padding(
+                padding: EdgeInsets.all(5.0),
+                child: Text(
+                  "(이)랑",
+                  style: TextStyle(
+                    fontSize: 18,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(
+            height: 10,
+          ),
+          Wrap(
+            spacing: 8,
+            children: _tagDepartment.map(
+              (tag) {
+                return ChoiceChip(
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                      side:
+                          const BorderSide(width: 2, color: Color(0xFFFEC2B5))),
+                  labelPadding: const EdgeInsets.fromLTRB(5, 0, 5, 0),
+                  label: SizedBox(
+                    width: 50,
+                    child: Text(
+                      tag.title,
+                      style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                            color: const Color(0xff1b1b1b),
+                            fontSize: 16,
+                            fontWeight: FontWeight.w400,
+                          ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  selected: department == tag.title,
+                  selectedColor: const Color(0xfffec2b5),
+                  onSelected: (selected) {
+                    setState(
+                      () {
+                        if (selected) {
+                          department = tag.title;
+                        } else {
+                          department = null;
+                        }
+                      },
+                    );
+                  },
+                  backgroundColor: Colors.white,
+                  elevation: 0,
+                );
               },
-              backgroundColor: Colors.white,
-              elevation: 0,
-            );
-          }).toList(),
-        ),
-        const SizedBox(
-          height: 10,
-        ),
-        Wrap(
-          spacing: 8,
-          children: _tagMethod.map((tag) {
-            return ChoiceChip(
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  side: const BorderSide(width: 2, color: Color(0xFFFEC2B5))),
-              labelPadding: const EdgeInsets.fromLTRB(5, 0, 5, 0),
-              label: Text(tag.title),
-              selected: method == tag.title,
-              selectedColor: const Color(0xFFFEC2B5),
-              onSelected: (selected) {
-                setState(() {
-                  if (selected) {
-                    method = tag.title;
-                  } else {
-                    method = null;
-                  }
-                });
+            ).toList(),
+          ),
+          Wrap(
+            spacing: 8,
+            children: _tagPerson.map((tag) {
+              return ChoiceChip(
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    side: const BorderSide(width: 2, color: Color(0xFFFEC2B5))),
+                labelPadding: const EdgeInsets.fromLTRB(5, 0, 5, 0),
+                label: SizedBox(
+                  width: 50,
+                  child: Text(
+                    tag.title,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      fontSize: 14,
+                    ),
+                  ),
+                ),
+                selected: person == tag.title,
+                selectedColor: const Color(0xFFFEC2B5),
+                onSelected: (selected) {
+                  setState(() {
+                    if (selected) {
+                      person = tag.title;
+                    } else {
+                      person = null;
+                    }
+                  });
+                },
+                backgroundColor: Colors.white,
+                elevation: 0,
+              );
+            }).toList(),
+          ),
+          const SizedBox(
+            height: 10,
+          ),
+          Row(
+            children: [
+              Container(
+                width: 156,
+                decoration: const BoxDecoration(
+                  border: BorderDirectional(
+                    bottom: BorderSide(
+                      color: Color(0xffc8aaaa),
+                      width: 1,
+                    ),
+                  ),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(5.0),
+                  child: Text(
+                    method ?? "",
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      fontSize: 18,
+                    ),
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(5.0),
+                child: Text(
+                  method == "카페" ? "가기" : "하기",
+                  style: const TextStyle(
+                    fontSize: 18,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(
+            height: 10,
+          ),
+          Wrap(
+            spacing: 8,
+            children: _tagMethod.map(
+              (tag) {
+                return ChoiceChip(
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                      side:
+                          const BorderSide(width: 2, color: Color(0xFFFEC2B5))),
+                  labelPadding: const EdgeInsets.fromLTRB(5, 0, 5, 0),
+                  label: Text(tag.title),
+                  selected: method == tag.title,
+                  selectedColor: const Color(0xFFFEC2B5),
+                  onSelected: (selected) {
+                    setState(() {
+                      if (selected) {
+                        method = tag.title;
+                      } else {
+                        method = null;
+                      }
+                    });
+                  },
+                  backgroundColor: Colors.white,
+                  elevation: 0,
+                );
               },
-              backgroundColor: Colors.white,
-              elevation: 0,
-            );
-          }).toList(),
-        ),
-        CustomTextField(
-          onChanged: (value) => {introduction = value},
-          obscureText: false,
-          hintText: "ex. 같이 카페에서 각자 공부할 사람 구해요!",
-        ),
-        CustomOutlinedButton(
+            ).toList(),
+          ),
+          const SizedBox(
+            height: 16,
+          ),
+          const Text(
+            "한줄 소개 (30자 이내)",
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w300,
+            ),
+          ),
+          CustomTextField(
+            onChanged: (value) => {introduction = value},
+            obscureText: false,
+            hintText: "ex. 같이 카페에서 각자 공부할 사람 구해요!",
+          ),
+          const SizedBox(
+            height: 40,
+          ),
+          CustomOutlinedButton(
             label: '저장',
             onPressed: () {
               if (place != null &&
@@ -251,8 +394,10 @@ class _ChoiceLocationState extends State<ChoiceLocation> {
                 _createTagset(context);
               }
             },
-            backgroundColor: const Color(0xfffec2b5))
-      ],
+            backgroundColor: const Color(0xfffec2b5),
+          )
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/tag_add_screen.dart
+++ b/lib/screens/tag_add_screen.dart
@@ -120,8 +120,13 @@ class _ChoiceLocationState extends State<ChoiceLocation> {
           spacing: 8,
           children: _tagPlace.map((tag) {
             return ChoiceChip(
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  side: const BorderSide(width: 2, color: Color(0xFFFEC2B5))),
+              labelPadding: const EdgeInsets.fromLTRB(5, 0, 5, 0),
               label: Text(tag.title),
               selected: place == tag.title,
+              selectedColor: const Color(0xfffec2b5),
               onSelected: (selected) {
                 setState(() {
                   if (selected) {
@@ -131,6 +136,8 @@ class _ChoiceLocationState extends State<ChoiceLocation> {
                   }
                 });
               },
+              backgroundColor: Colors.white,
+              elevation: 0,
             );
           }).toList(),
         ),
@@ -139,21 +146,39 @@ class _ChoiceLocationState extends State<ChoiceLocation> {
         ),
         Wrap(
           spacing: 8,
-          children: _tagDepartment.map((tag) {
-            return ChoiceChip(
-              label: Text(tag.title),
-              selected: department == tag.title,
-              onSelected: (selected) {
-                setState(() {
-                  if (selected) {
-                    department = tag.title;
-                  } else {
-                    department = null;
-                  }
-                });
-              },
-            );
-          }).toList(),
+          children: _tagDepartment.map(
+            (tag) {
+              return ChoiceChip(
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    side: const BorderSide(width: 2, color: Color(0xFFFEC2B5))),
+                labelPadding: const EdgeInsets.fromLTRB(5, 0, 5, 0),
+                label: Text(
+                  tag.title,
+                  style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                        color: const Color(0xff1b1b1b),
+                        fontSize: 16,
+                        fontWeight: FontWeight.w400,
+                      ),
+                ),
+                selected: department == tag.title,
+                selectedColor: const Color(0xfffec2b5),
+                onSelected: (selected) {
+                  setState(
+                    () {
+                      if (selected) {
+                        department = tag.title;
+                      } else {
+                        department = null;
+                      }
+                    },
+                  );
+                },
+                backgroundColor: Colors.white,
+                elevation: 0,
+              );
+            },
+          ).toList(),
         ),
         const SizedBox(
           height: 10,
@@ -162,8 +187,13 @@ class _ChoiceLocationState extends State<ChoiceLocation> {
           spacing: 8,
           children: _tagPerson.map((tag) {
             return ChoiceChip(
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  side: const BorderSide(width: 2, color: Color(0xFFFEC2B5))),
+              labelPadding: const EdgeInsets.fromLTRB(5, 0, 5, 0),
               label: Text(tag.title),
               selected: person == tag.title,
+              selectedColor: const Color(0xFFFEC2B5),
               onSelected: (selected) {
                 setState(() {
                   if (selected) {
@@ -173,6 +203,8 @@ class _ChoiceLocationState extends State<ChoiceLocation> {
                   }
                 });
               },
+              backgroundColor: Colors.white,
+              elevation: 0,
             );
           }).toList(),
         ),
@@ -183,8 +215,13 @@ class _ChoiceLocationState extends State<ChoiceLocation> {
           spacing: 8,
           children: _tagMethod.map((tag) {
             return ChoiceChip(
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  side: const BorderSide(width: 2, color: Color(0xFFFEC2B5))),
+              labelPadding: const EdgeInsets.fromLTRB(5, 0, 5, 0),
               label: Text(tag.title),
               selected: method == tag.title,
+              selectedColor: const Color(0xFFFEC2B5),
               onSelected: (selected) {
                 setState(() {
                   if (selected) {
@@ -194,6 +231,8 @@ class _ChoiceLocationState extends State<ChoiceLocation> {
                   }
                 });
               },
+              backgroundColor: Colors.white,
+              elevation: 0,
             );
           }).toList(),
         ),

--- a/lib/screens/tag_add_screen.dart
+++ b/lib/screens/tag_add_screen.dart
@@ -376,10 +376,14 @@ class _ChoiceLocationState extends State<ChoiceLocation> {
               fontWeight: FontWeight.w300,
             ),
           ),
+          const SizedBox(
+            height: 8,
+          ),
           CustomTextField(
             onChanged: (value) => {introduction = value},
             obscureText: false,
             hintText: "ex. 같이 카페에서 각자 공부할 사람 구해요!",
+            padding: const EdgeInsets.all(0.0),
           ),
           const SizedBox(
             height: 40,

--- a/lib/widgets/custom_textfield.dart
+++ b/lib/widgets/custom_textfield.dart
@@ -9,6 +9,7 @@ class CustomTextField extends StatelessWidget {
   final VoidCallback? onPressed;
   final String? errorText;
   final String? helperText;
+  final EdgeInsets? padding;
 
   const CustomTextField({
     super.key,
@@ -21,12 +22,13 @@ class CustomTextField extends StatelessWidget {
     this.errorText,
     this.onPressed,
     this.helperText,
+    this.padding,
   });
 
   @override
   Widget build(BuildContext context) {
     return Padding(
-        padding: const EdgeInsets.fromLTRB(30, 5, 30, 0),
+        padding: padding ?? const EdgeInsets.fromLTRB(30, 5, 30, 0),
         child: Stack(
           alignment: Alignment.centerRight,
           children: [

--- a/lib/widgets/custom_textfield.dart
+++ b/lib/widgets/custom_textfield.dart
@@ -10,6 +10,7 @@ class CustomTextField extends StatelessWidget {
   final String? errorText;
   final String? helperText;
   final EdgeInsets? padding;
+  final int? textLimit;
 
   const CustomTextField({
     super.key,
@@ -23,6 +24,7 @@ class CustomTextField extends StatelessWidget {
     this.onPressed,
     this.helperText,
     this.padding,
+    this.textLimit,
   });
 
   @override
@@ -33,6 +35,7 @@ class CustomTextField extends StatelessWidget {
           alignment: Alignment.centerRight,
           children: [
             TextField(
+                maxLength: textLimit,
                 controller: controller,
                 obscureText: obscureText,
                 onChanged: onChanged,


### PR DESCRIPTION
This PR resolves #42 

Figma에서 가이드된 디자인에 따라 UI를 재구성하였습니다.
- `ChoiceChip` 디자인 수정
- 누락된 `Text` 위젯들 추가


---
**추가 전달 사항(@ima9ine4 )**

작업 과정 중 `CustomTextField`가 수정 되었습니다.
1. `padding` field 추가 - [관련 commit](https://github.com/TEAM-LINRING/LINRING-FRONT-FLUTTER/commit/f24945a703ce80adcb3456982b49a13d172a8a10)
2. `textLimit` field 추가 - [관련 commit](https://github.com/TEAM-LINRING/LINRING-FRONT-FLUTTER/commit/80e8e4ffed644fa3b61c20d413f36d6dc09dc05b)

각 관련 commit의 본문(body)에 더 상세히 기재해두었으며 간단하게 설명하면 아래와 같은 이유로 변경하였습니다.
- `TextField`의 경우, `maxLength`의 속성을 상황 별로 다르게 적용하는 경우가 많습니다 -> 따로 재사용 가능하는 과정에서 설정할 수 있도록 만들어주는 것이 권장되는 방법입니다.
- `padding` 값은 재사용 가능 위젯(이 경우에는 `CustomText`)에서 fix 해두는 것보다 flexible하게 사용할 수 있도록 파라미터로 전달 받도록 구현하는 것이 더 좋습니다. 웹의 Component와 앱의 Widget에서 별 다른 margin, padding 값을 부여하지 않고 전달 받도록 하는 이유 중 하나입니다.

추가로 작업하다가 확장이 필요한 경우에는 Custom Widget을 일반화하여 수정하는 것으로 작업해주세요 :)