### PR TITLE
Feat/chat widgets UI

### DIFF
--- a/lib/models/chat_model.dart
+++ b/lib/models/chat_model.dart
@@ -29,7 +29,7 @@ class ChatRoom {
       relation2: User.fromJson(json["relation2"]),
       tag: Tagset.fromJson(json["tagset"]),
       tag2: Tagset.fromJson(json["tagset2"]),
-      notice: json["notice"] ?? 0,
+      notice: json["notice"],
       created: DateTime.parse(json["created"]),
       modified: DateTime.parse(json["modified"]),
     );

--- a/lib/models/chat_model.dart
+++ b/lib/models/chat_model.dart
@@ -16,10 +16,10 @@ class ChatRoom {
 
   factory ChatRoom.fromJson(Map<String, dynamic> json) {
     return ChatRoom(
-      relation: json["relation"],
-      relation2: json["relation2"],
-      tag: json["tagset"],
-      tag2: json["tagset2"],
+      relation: User.fromJson(json["relation"]),
+      relation2: User.fromJson(json["relation2"]),
+      tag: tagset.fromJson(json["tagset"]),
+      tag2: tagset.fromJson(json["tagset2"]),
     );
   }
 }

--- a/lib/models/chat_model.dart
+++ b/lib/models/chat_model.dart
@@ -2,24 +2,36 @@ import 'package:linring_front_flutter/models/tagset_model.dart';
 import 'package:linring_front_flutter/models/user_model.dart';
 
 class ChatRoom {
+  final int id;
   final User relation;
   final User relation2;
   final tagset tag;
   final tagset tag2;
+  final int? notice;
+  final DateTime created;
+  final DateTime modified;
 
   ChatRoom({
+    required this.id,
     required this.relation,
     required this.relation2,
     required this.tag,
     required this.tag2,
+    required this.notice,
+    required this.created,
+    required this.modified,
   });
 
   factory ChatRoom.fromJson(Map<String, dynamic> json) {
     return ChatRoom(
+      id: json["id"],
       relation: User.fromJson(json["relation"]),
       relation2: User.fromJson(json["relation2"]),
       tag: tagset.fromJson(json["tagset"]),
       tag2: tagset.fromJson(json["tagset2"]),
+      notice: json["notice"] ?? 0,
+      created: DateTime.parse(json["created"]),
+      modified: DateTime.parse(json["modified"]),
     );
   }
 }

--- a/lib/models/chat_model.dart
+++ b/lib/models/chat_model.dart
@@ -1,17 +1,31 @@
+import 'package:linring_front_flutter/models/tagset_model.dart';
 import 'package:linring_front_flutter/models/user_model.dart';
 
-class Room {
+class ChatRoom {
   final User relation;
   final User relation2;
+  final tagset tag;
+  final tagset tag2;
 
-  Room({
+  ChatRoom({
     required this.relation,
     required this.relation2,
+    required this.tag,
+    required this.tag2,
   });
+
+  factory ChatRoom.fromJson(Map<String, dynamic> json) {
+    return ChatRoom(
+      relation: json["relation"],
+      relation2: json["relation2"],
+      tag: json["tagset"],
+      tag2: json["tagset2"],
+    );
+  }
 }
 
 class Message {
-  final Room room;
+  final ChatRoom room;
   final User sender;
   final User receiver;
   final String message;
@@ -29,62 +43,3 @@ class Message {
     this.args,
   });
 }
-
-// 테스트용 더미 데이터
-final List<Room> allRoom = [
-  Room(
-    relation: User(
-      name: "CJW",
-    ),
-    relation2: User(
-      name: "Hanata",
-    ),
-  ),
-  Room(
-    relation: User(
-      name: "CJW",
-    ),
-    relation2: User(
-      name: "WJC",
-    ),
-  ),
-];
-
-final List<Message> allMessage = [
-  Message(
-    room: allRoom[0],
-    sender: allRoom[0].relation,
-    receiver: allRoom[0].relation2,
-    message: "안녕하세요 저는 최지원입니다.",
-    isRead: true,
-    type: 1,
-    args: null,
-  ),
-  Message(
-    room: allRoom[0],
-    sender: allRoom[0].relation2,
-    receiver: allRoom[0].relation,
-    message: "반갑습니다. 저는 하나타입니다.",
-    isRead: true,
-    type: 1,
-    args: null,
-  ),
-  Message(
-    room: allRoom[0],
-    sender: allRoom[0].relation,
-    receiver: allRoom[0].relation2,
-    message: "저희 언제 만나는 걸로 할까요?",
-    isRead: true,
-    type: 1,
-    args: null,
-  ),
-  Message(
-    room: allRoom[0],
-    sender: allRoom[0].relation,
-    receiver: allRoom[0].relation2,
-    message: "내일은 괜찮으신가요?",
-    isRead: true,
-    type: 1,
-    args: null,
-  ),
-];

--- a/lib/models/chat_model.dart
+++ b/lib/models/chat_model.dart
@@ -5,8 +5,8 @@ class ChatRoom {
   final int id;
   final User relation;
   final User relation2;
-  final tagset tag;
-  final tagset tag2;
+  final Tagset tag;
+  final Tagset tag2;
   final int? notice;
   final DateTime created;
   final DateTime modified;
@@ -27,8 +27,8 @@ class ChatRoom {
       id: json["id"],
       relation: User.fromJson(json["relation"]),
       relation2: User.fromJson(json["relation2"]),
-      tag: tagset.fromJson(json["tagset"]),
-      tag2: tagset.fromJson(json["tagset2"]),
+      tag: Tagset.fromJson(json["tagset"]),
+      tag2: Tagset.fromJson(json["tagset2"]),
       notice: json["notice"] ?? 0,
       created: DateTime.parse(json["created"]),
       modified: DateTime.parse(json["modified"]),

--- a/lib/models/tagset_model.dart
+++ b/lib/models/tagset_model.dart
@@ -1,4 +1,4 @@
-class tagset {
+class Tagset {
   final int id;
   final DateTime created;
   final DateTime modified;
@@ -10,7 +10,7 @@ class tagset {
   final String? introduction;
   final int owner;
 
-  tagset({
+  Tagset({
     required this.id,
     required this.created,
     required this.modified,
@@ -23,8 +23,8 @@ class tagset {
     required this.owner,
   });
 
-  factory tagset.fromJson(Map<String, dynamic> json) {
-    return tagset(
+  factory Tagset.fromJson(Map<String, dynamic> json) {
+    return Tagset(
       id: json["id"],
       created: DateTime.parse(json["created"]),
       modified: DateTime.parse(json["modified"]),

--- a/lib/models/tagset_model.dart
+++ b/lib/models/tagset_model.dart
@@ -33,7 +33,7 @@ class tagset {
       person: json["person"],
       method: json["method"],
       isActive: json["is_active"],
-      introduction: json["introduction"],
+      introduction: json["introduction"] ?? "",
       owner: json["owner"],
     );
   }

--- a/lib/models/user_model.dart
+++ b/lib/models/user_model.dart
@@ -1,8 +1,60 @@
+import 'dart:ffi';
+
 class User {
-  final String name;
+  final int id;
+  final DateTime? lastLogin;
+  final DateTime created;
+  final DateTime modified;
+  final String username;
+  final String email;
+  final String nickname;
+  final String? profile;
+  final String department;
+  final int? studentNumber;
+  final String gender;
+  final String? significant;
+  final String? rating;
+  final bool isActive;
+  final Array groups;
+  final Array userPermissions;
 
   User({
-    required this.name,
+    required this.id,
+    required this.lastLogin,
+    required this.created,
+    required this.modified,
+    required this.username,
+    required this.email,
+    required this.nickname,
+    required this.profile,
+    required this.department,
+    required this.studentNumber,
+    required this.gender,
+    required this.significant,
+    required this.rating,
+    required this.isActive,
+    required this.groups,
+    required this.userPermissions,
   });
-}
 
+  factory User.fromJson(Map<String, dynamic> json) {
+    return User(
+      id: json["id"],
+      lastLogin: DateTime.parse(json["last_login"]),
+      created: DateTime.parse(json["created"]),
+      modified: DateTime.parse(json["modified"]),
+      username: json["username"],
+      email: json["email"],
+      nickname: json["nickname"],
+      profile: json["profile"],
+      department: json["department"],
+      studentNumber: json["student_number"],
+      gender: json["gender"],
+      significant: json["significant"],
+      rating: json["rating"],
+      isActive: json["is_active"],
+      groups: json["groups"],
+      userPermissions: json["user_permissions"],
+    );
+  }
+}

--- a/lib/models/user_model.dart
+++ b/lib/models/user_model.dart
@@ -1,5 +1,3 @@
-import 'dart:ffi';
-
 class User {
   final int id;
   final DateTime? lastLogin;
@@ -12,11 +10,11 @@ class User {
   final String department;
   final int? studentNumber;
   final String gender;
-  final String? significant;
   final String? rating;
   final bool isActive;
-  final Array groups;
-  final Array userPermissions;
+  final List<dynamic>? groups;
+  final List<String>? userPermissions;
+  final List<int>? significant;
 
   User({
     required this.id,
@@ -30,11 +28,11 @@ class User {
     required this.department,
     required this.studentNumber,
     required this.gender,
-    required this.significant,
     required this.rating,
     required this.isActive,
     required this.groups,
     required this.userPermissions,
+    required this.significant,
   });
 
   factory User.fromJson(Map<String, dynamic> json) {
@@ -46,15 +44,15 @@ class User {
       username: json["username"],
       email: json["email"],
       nickname: json["nickname"],
-      profile: json["profile"],
+      profile: json["profile"] ?? "",
       department: json["department"],
-      studentNumber: json["student_number"],
+      studentNumber: json["student_number"] ?? 00000000,
       gender: json["gender"],
-      significant: json["significant"],
-      rating: json["rating"],
+      rating: json["rating"] ?? "",
       isActive: json["is_active"],
-      groups: json["groups"],
-      userPermissions: json["user_permissions"],
+      groups: json["groups"] ?? [],
+      userPermissions: json["user_permissions"] ?? [],
+      significant: json["significant"] ?? [],
     );
   }
 }

--- a/lib/screens/chat_room_screen.dart
+++ b/lib/screens/chat_room_screen.dart
@@ -36,10 +36,9 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> {
     );
 
     if (response.statusCode == 200) {
-      print(response.body);
-      List<dynamic> body = jsonDecode(utf8.decode(response.bodyBytes));
+      final List parsedList = json.decode(utf8.decode(response.bodyBytes));
       List<ChatRoom> rooms =
-          body.map((dynamic e) => ChatRoom.fromJson(e)).toList();
+          parsedList.map((val) => ChatRoom.fromJson(val)).toList();
       return rooms;
     } else {
       throw Exception('Failed to load chat rooms.');

--- a/lib/screens/chat_room_screen.dart
+++ b/lib/screens/chat_room_screen.dart
@@ -1,8 +1,49 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
 import 'package:linring_front_flutter/models/chat_model.dart';
 
-class ChatRoomScreen extends StatelessWidget {
-  const ChatRoomScreen({super.key});
+class ChatRoomScreen extends StatefulWidget {
+  const ChatRoomScreen({Key? key}) : super(key: key);
+
+  @override
+  State createState() => _ChatRoomScreenState();
+}
+
+class _ChatRoomScreenState extends State<ChatRoomScreen> {
+  late Future<List<ChatRoom>> _futureRooms;
+
+  @override
+  void initState() {
+    super.initState();
+    _futureRooms = _loadChatRooms();
+  }
+
+  String token = "TOKEN";
+
+  Future<List<ChatRoom>> _loadChatRooms() async {
+    String apiAddress = dotenv.get("API_ADDRESS");
+    final url = Uri.parse('$apiAddress/chat/room/');
+    final response = await http.get(
+      url,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token'
+      },
+    );
+
+    if (response.statusCode == 200) {
+      print(response.body);
+      List<dynamic> body = jsonDecode(utf8.decode(response.bodyBytes));
+      List<ChatRoom> rooms =
+          body.map((dynamic e) => ChatRoom.fromJson(e)).toList();
+      return rooms;
+    } else {
+      throw Exception('Failed to load chat rooms.');
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -19,36 +60,51 @@ class ChatRoomScreen extends StatelessWidget {
           ),
         ),
       ),
-      body: ListView.builder(
-        itemCount: allRoom.length,
-        itemBuilder: (context, int index) {
-          Room room = allRoom[index];
-          return _chatRoom(room, context);
+      body: FutureBuilder(
+        future: _futureRooms,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const CircularProgressIndicator();
+          } else if (snapshot.hasError) {
+            return Text("에러 ${snapshot.error}");
+          } else if (!snapshot.hasData) {
+            return const Text("데이터 없음.");
+          } else {
+            List<ChatRoom>? rooms = snapshot.data;
+            return ListView.builder(
+              itemCount: rooms?.length,
+              itemBuilder: (context, int index) {
+                ChatRoom room = rooms![index];
+                return _chatRoom(room, context);
+              },
+            );
+          }
         },
       ),
     );
   }
 
-  Widget _chatRoom(Room room, BuildContext context) {
+  Widget _chatRoom(ChatRoom room, BuildContext context) {
     return InkWell(
       onTap: () => {Navigator.pushNamed(context, '/chat')},
       child: Container(
         margin: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
-        child: const Row(
+        child: Row(
           children: [
-            CircleAvatar(
+            const CircleAvatar(
               backgroundColor: Color(0xffd9d9d9),
               radius: 28,
             ),
-            SizedBox(
+            const SizedBox(
               width: 14,
             ),
             Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text("Hanata"),
-                Text("#태그 #태그 #태그"),
-                Text("최근 대화 내용"),
+                Text(room.relation2.nickname),
+                Text(
+                    "#${room.tag2.place} #${room.tag2.owner} #${room.tag2.method}"),
+                const Text("최근 대화 내용"),
               ],
             )
           ],

--- a/lib/screens/chat_room_screen.dart
+++ b/lib/screens/chat_room_screen.dart
@@ -23,11 +23,10 @@ class _ChatRoomScreenState extends State<ChatRoomScreen> {
     _futureRooms = _loadChatRooms();
   }
 
-  String token = "TOKEN";
-
   Future<List<ChatRoom>> _loadChatRooms() async {
     String apiAddress = dotenv.get("API_ADDRESS");
     final url = Uri.parse('$apiAddress/chat/room/');
+    final token = widget.loginInfo.access;
     final response = await http.get(
       url,
       headers: {

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -32,29 +32,29 @@ class _ChatScreenState extends State<ChatScreen> {
   final _controller = TextEditingController();
   final _scrollController = ScrollController();
 
-  void _sendMessage() {
-    FocusScope.of(context).unfocus();
-    // 서버에 채팅 메세지 전송하는 것으로 변경 예정
-    allMessage.add(
-      Message(
-        room: Room(
-          relation: User(name: 'CJW'),
-          relation2: User(name: 'Hanata'),
-        ),
-        sender: User(name: 'CJW'),
-        receiver: User(name: 'Hanata'),
-        message: _enteredMessage,
-        isRead: true,
-        type: 1,
-      ),
-    );
-    _controller.clear();
-    _scrollController.animateTo(
-      0,
-      duration: const Duration(milliseconds: 300),
-      curve: Curves.easeInOut,
-    );
-  }
+  // void _sendMessage() {
+  //   FocusScope.of(context).unfocus();
+  //   // 서버에 채팅 메세지 전송하는 것으로 변경 예정
+  //   allMessage.add(
+  //     Message(
+  //       room: Room(
+  //         relation: User(name: 'CJW'),
+  //         relation2: User(name: 'Hanata'),
+  //       ),
+  //       sender: User(name: 'CJW'),
+  //       receiver: User(name: 'Hanata'),
+  //       message: _enteredMessage,
+  //       isRead: true,
+  //       type: 1,
+  //     ),
+  //   );
+  //   _controller.clear();
+  //   _scrollController.animateTo(
+  //     0,
+  //     duration: const Duration(milliseconds: 300),
+  //     curve: Curves.easeInOut,
+  //   );
+  // }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -65,7 +65,7 @@ class _ChatScreenState extends State<ChatScreen> {
       body: Column(
         children: [
           _matchInfo(),
-          _chatContainer(),
+          // _chatContainer(),
           _chatInput(),
         ],
       ),
@@ -99,46 +99,46 @@ class _ChatScreenState extends State<ChatScreen> {
     );
   }
 
-  Widget _chatContainer() {
-    List<Message> messages = List.from(allMessage.reversed);
+  // Widget _chatContainer() {
+  //   List<Message> messages = List.from(allMessage.reversed);
 
-    return Expanded(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 14),
-        child: GestureDetector(
-          onTap: () {
-            FocusScope.of(context).unfocus(); // 가상 키보드 unfocusing
-          },
-          child: Align(
-            alignment: Alignment.topCenter,
-            child: ListView.builder(
-              shrinkWrap: true,
-              reverse: true,
-              controller: _scrollController,
-              itemCount: messages.length,
-              itemBuilder: (context, int index) {
-                final message = messages[index];
-                // email로 해야하는데 임시로 이름으로 해두었습니다.
-                bool isMine = message.sender.name == logginedUser;
-                return Container(
-                  margin: const EdgeInsets.only(top: 8),
-                  child: Row(
-                    mainAxisAlignment: isMine
-                        ? MainAxisAlignment.end
-                        : MainAxisAlignment.start,
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    children: [
-                      _chatBubble(message, isMine),
-                    ],
-                  ),
-                );
-              },
-            ),
-          ),
-        ),
-      ),
-    );
-  }
+  //   return Expanded(
+  //     child: Padding(
+  //       padding: const EdgeInsets.symmetric(horizontal: 14),
+  //       child: GestureDetector(
+  //         onTap: () {
+  //           FocusScope.of(context).unfocus(); // 가상 키보드 unfocusing
+  //         },
+  //         child: Align(
+  //           alignment: Alignment.topCenter,
+  //           child: ListView.builder(
+  //             shrinkWrap: true,
+  //             reverse: true,
+  //             controller: _scrollController,
+  //             itemCount: messages.length,
+  //             itemBuilder: (context, int index) {
+  //               final message = messages[index];
+  //               // email로 해야하는데 임시로 이름으로 해두었습니다.
+  //               bool isMine = message.sender.name == logginedUser;
+  //               return Container(
+  //                 margin: const EdgeInsets.only(top: 8),
+  //                 child: Row(
+  //                   mainAxisAlignment: isMine
+  //                       ? MainAxisAlignment.end
+  //                       : MainAxisAlignment.start,
+  //                   crossAxisAlignment: CrossAxisAlignment.end,
+  //                   children: [
+  //                     _chatBubble(message, isMine),
+  //                   ],
+  //                 ),
+  //               );
+  //             },
+  //           ),
+  //         ),
+  //       ),
+  //     ),
+  //   );
+  // }
 
   // 매칭 정보(태그 정보, 약속 시간 표시)
   Widget _matchInfo() {
@@ -230,15 +230,15 @@ class _ChatScreenState extends State<ChatScreen> {
                   },
                 ),
               ),
-              IconButton(
-                highlightColor: Colors.transparent, // 물결 효과 제거
-                splashColor: Colors.transparent, // 물결 효과 제거
-                onPressed: _enteredMessage.trim().isEmpty ? null : _sendMessage,
-                icon: Image.asset(
-                  "assets/icons/send_button.png",
-                  width: 20,
-                ),
-              )
+              // IconButton(
+              //   highlightColor: Colors.transparent, // 물결 효과 제거
+              //   splashColor: Colors.transparent, // 물결 효과 제거
+              //   onPressed: _enteredMessage.trim().isEmpty ? null : _sendMessage,
+              //   icon: Image.asset(
+              //     "assets/icons/send_button.png",
+              //     width: 20,
+              //   ),
+              // )
             ]),
           ),
         ),

--- a/lib/screens/tag_show_screen.dart
+++ b/lib/screens/tag_show_screen.dart
@@ -24,11 +24,10 @@ class _TagShowScreenState extends State<TagShowScreen> {
     _futureTagsets = _callAPI();
   }
 
-  String token = "TOKEN";
-
   Future<List<tagset>> _callAPI() async {
     String apiAddress = dotenv.get("API_ADDRESS");
     final url = Uri.parse('$apiAddress/accounts/v2/tagset/');
+    final token = widget.loginInfo.access;
     final response = await http.get(
       url,
       headers: {

--- a/lib/screens/tag_show_screen.dart
+++ b/lib/screens/tag_show_screen.dart
@@ -17,14 +17,14 @@ class TagShowScreen extends StatefulWidget {
 }
 
 class _TagShowScreenState extends State<TagShowScreen> {
-  late Future<List<tagset>> _futureTagsets;
+  late Future<List<Tagset>> _futureTagsets;
   @override
   void initState() {
     super.initState();
     _futureTagsets = _callAPI();
   }
 
-  Future<List<tagset>> _callAPI() async {
+  Future<List<Tagset>> _callAPI() async {
     String apiAddress = dotenv.get("API_ADDRESS");
     final url = Uri.parse('$apiAddress/accounts/v2/tagset/');
     final token = widget.loginInfo.access;
@@ -38,8 +38,8 @@ class _TagShowScreenState extends State<TagShowScreen> {
 
     if (response.statusCode == 200) {
       List<dynamic> body = jsonDecode(utf8.decode(response.bodyBytes));
-      List<tagset> tagsets =
-          body.map((dynamic e) => tagset.fromJson(e)).toList();
+      List<Tagset> tagsets =
+          body.map((dynamic e) => Tagset.fromJson(e)).toList();
       return tagsets;
     } else {
       throw Exception('Failed to load tagset.');

--- a/lib/screens/tag_show_screen.dart
+++ b/lib/screens/tag_show_screen.dart
@@ -22,12 +22,18 @@ class _TagShowScreenState extends State<TagShowScreen> {
     _futureTagsets = _callAPI();
   }
 
+  String token = "TOKEN";
+
   Future<List<tagset>> _callAPI() async {
     String apiAddress = dotenv.get("API_ADDRESS");
     final url = Uri.parse('$apiAddress/accounts/v2/tagset/');
-    final response = await http.get(url, headers: {
-      'Content-Type': 'application/json',
-    });
+    final response = await http.get(
+      url,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token'
+      },
+    );
 
     if (response.statusCode == 200) {
       List<dynamic> body = jsonDecode(utf8.decode(response.bodyBytes));

--- a/lib/widgets/custom_profile_modal.dart
+++ b/lib/widgets/custom_profile_modal.dart
@@ -8,9 +8,7 @@ class CustomProfileModal extends StatelessWidget {
     required this.tag,
   });
 
-  final tagset tag;
-
-  
+  final Tagset tag;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/custom_profile_modal.dart
+++ b/lib/widgets/custom_profile_modal.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:linring_front_flutter/models/tagset_model.dart';
+import 'package:linring_front_flutter/models/user_model.dart';
+
+class CustomProfileModal extends StatelessWidget {
+  const CustomProfileModal({
+    super.key,
+    required this.tag,
+  });
+
+  final tagset tag;
+
+  
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Row(
+          mainAxisSize: MainAxisSize.max,
+          children: [
+            CircleAvatar(),
+            Column(
+              children: [
+                Text(""),
+                Text(""),
+              ],
+            )
+          ],
+        ),
+        Text(tag.introduction ?? ""),
+        const ButtonBar(),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
This PR closes #41 

기존 Epic 문제(#48)로 인하여 Issue 진행이 원활하게 이루어지지 않아 task를 분리하여 여러 새 Issue로 재할당하고자 합니다.
해당 작업을 위하여 현재까지의 `feat/chat-widgets-ui`의 변경 상황을 `main` 브랜치에 반영합니다.

아래는 본 PR에서의 변경 사항입니다.

- `ChatRoom` get API 연결
- 커스텀 프로필 모달 skeleton UI 구현
- http 요청 시, Token 전달하도록 수정
- `tagset` -> `Tagset` 모델명 변경